### PR TITLE
Redirect unauthenticated users to login before dashboard access

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,27 +1,30 @@
-from django.shortcuts import render
-from django.contrib.auth.decorators import login_required
+from django.shortcuts import render, redirect
 
-@login_required
 def hub_view(request):
     """Render the hub page."""
+    if not request.user.is_authenticated:
+        return redirect('login')
     return render(request, 'dashboard/hub.html')
 
 
-@login_required
 def settings_view(request):
     """Render the settings page."""
+    if not request.user.is_authenticated:
+        return redirect('login')
     return render(request, 'dashboard/settings.html')
 
 
-@login_required
 def settings_detail_view(request, container_id):
     """Render the settings detail page for a container."""
+    if not request.user.is_authenticated:
+        return redirect('login')
     context = {"container_id": container_id}
     return render(request, 'dashboard/settings_detail.html', context)
 
 
-@login_required
 def container_view(request, container_id):
     """Render the container chat page."""
+    if not request.user.is_authenticated:
+        return redirect('login')
     context = {"container_id": container_id}
     return render(request, 'dashboard/container.html', context)

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -123,7 +123,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Auth settings
 LOGIN_URL = 'login'
-LOGIN_REDIRECT_URL = 'hub'
+LOGIN_REDIRECT_URL = 'dashboard:hub'
 LOGOUT_REDIRECT_URL = 'login'
 
 # Custom Authentication Backend


### PR DESCRIPTION
## Summary
- Remove `login_required` decorators and manually redirect unauthenticated requests in dashboard views
- Configure `LOGIN_REDIRECT_URL` to point to `dashboard:hub`

## Testing
- `SECRET_KEY=testkey DEBUG=True DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/1 python manage.py test`
- `SECRET_KEY=testkey DEBUG=True DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/1 python manage.py shell <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68a0d43c11e08327bc5653d78856dafa