### PR TITLE
Ensure login default redirect to hub

### DIFF
--- a/portal/settings.py
+++ b/portal/settings.py
@@ -123,7 +123,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Auth settings
 LOGIN_URL = 'login'
-LOGIN_REDIRECT_URL = 'dashboard:hub'
+LOGIN_REDIRECT_URL = 'dashboard:hub'  # Default redirect after login
 LOGOUT_REDIRECT_URL = 'login'
 
 # Custom Authentication Backend
@@ -149,3 +149,4 @@ MS_AUTHORITY = env('MS_AUTHORITY', default=None)
 MS_REDIRECT_PATH = "/accounts/microsoft/callback/"
 MS_ENDPOINT = 'https://graph.microsoft.com/v1.0/me'
 MS_SCOPE = ["User.Read"]
+

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+class LoginRedirectTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass123")
+
+    def test_redirects_to_hub_when_no_next(self):
+        response = self.client.post(reverse('login'), {
+            'username': 'tester',
+            'password': 'pass123',
+        })
+        self.assertRedirects(response, reverse('dashboard:hub'))


### PR DESCRIPTION
## Summary
- clarify LOGIN_REDIRECT_URL defaults to dashboard hub
- test login redirect when no `next` parameter

## Testing
- `python manage.py test users.tests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a0d61972288327851c5330248328fe