### PR TITLE
Add containers list view and navigation link

### DIFF
--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+from .models import Container
+
+
+class ContainersListViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass123")
+        Container.objects.create(name="Test Container", owner=self.user)
+
+    def test_redirects_when_not_logged_in(self):
+        response = self.client.get(reverse('dashboard:containers_list'))
+        self.assertRedirects(response, reverse('login'))
+
+    def test_lists_containers_when_logged_in(self):
+        self.client.login(username="tester", password="pass123")
+        response = self.client.get(reverse('dashboard:containers_list'))
+        self.assertContains(response, "Test Container")

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import hub_view, settings_view, settings_detail_view, container_view
+from .views import hub_view, settings_view, settings_detail_view, container_view, containers_list_view
 
 app_name = 'dashboard'
 
@@ -7,5 +7,6 @@ urlpatterns = [
     path('', hub_view, name='hub'),
     path('settings/', settings_view, name='settings'),
     path('settings/<int:container_id>/', settings_detail_view, name='settings_detail'),
+    path('containers/', containers_list_view, name='containers_list'),
     path('containers/<int:container_id>/', container_view, name='container'),
 ]

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,5 +1,7 @@
 from django.shortcuts import render, redirect
 
+from .models import Container
+
 def hub_view(request):
     """Render the hub page."""
     if not request.user.is_authenticated:
@@ -28,3 +30,12 @@ def container_view(request, container_id):
         return redirect('login')
     context = {"container_id": container_id}
     return render(request, 'dashboard/container.html', context)
+
+
+def containers_list_view(request):
+    """Render a list of available containers."""
+    if not request.user.is_authenticated:
+        return redirect('login')
+    containers = Container.objects.all()
+    context = {"containers": containers}
+    return render(request, 'dashboard/containers_list.html', context)

--- a/templates/dashboard/base_portal.html
+++ b/templates/dashboard/base_portal.html
@@ -6,6 +6,9 @@
 {% block content %}
     <header class="portal-header hidden" id="portal-header">
         <h1 class="portal-title-main">AI Department Portal</h1>
+        <nav class="portal-nav">
+            <a href="{% url 'dashboard:containers_list' %}">Containers</a>
+        </nav>
         <div class="user-profile" id="user-profile">
             <!-- User info will be injected here by JS. -->
         </div>

--- a/templates/dashboard/containers_list.html
+++ b/templates/dashboard/containers_list.html
@@ -1,0 +1,14 @@
+{% extends "dashboard/base_portal.html" %}
+
+{% block portal_content %}
+<div id="containers-list-page">
+    <h1 class="containers-title">Available Containers</h1>
+    <ul class="containers-list">
+        {% for container in containers %}
+            <li><a href="{% url 'dashboard:container' container.id %}">{{ container.name }}</a></li>
+        {% empty %}
+            <li>No containers available.</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add containers_list_view to show available containers
- wire up containers list URL and template
- expose Containers link in portal navigation

## Testing
- `docker-compose exec web pytest` *(fails: command not found)*
- `python manage.py test dashboard.tests.ContainersListViewTests --verbosity=2`
- `docker-compose restart web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d9756ec48327b6df79f1d9f07eca