### PR TITLE
Simplify header user profile layout and update styles

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -207,6 +207,7 @@ a:hover {
     display: flex;
     align-items: center;
     gap: 1rem;
+    flex-wrap: nowrap;
 }
 
 .user-avatar {
@@ -229,7 +230,7 @@ a:hover {
     object-fit: cover;
 }
 
-.user-info .user-name {
+.user-name {
     font-weight: 500;
     display: block;
 }
@@ -248,7 +249,7 @@ a:hover {
     transition: color 0.2s ease, background-color 0.2s ease;
 }
 .logout-btn:hover {
-    color: var(--accent-color);
+    color: var(--error-color);
     background: rgba(255, 255, 255, 0.1);
     text-decoration: none;
 }

--- a/static/js/portal.js
+++ b/static/js/portal.js
@@ -165,13 +165,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         userProfileContainer.innerHTML = `
             <div class="user-avatar">${avatarContent}</div>
-            <div class="user-info">
-                <span class="user-name">${fullName}</span>
-                <form action="/accounts/logout/" method="post" style="display: inline;">
-                    <input type="hidden" name="csrfmiddlewaretoken" value="${csrftoken}">
-                    <button type="submit" class="logout-btn">Logout</button>
-                </form>
-            </div>
+            <span class="user-name">${fullName}</span>
+            <form action="/accounts/logout/" method="post">
+                <input type="hidden" name="csrfmiddlewaretoken" value="${csrftoken}">
+                <button type="submit" class="logout-btn">Logout</button>
+            </form>
         `;
         portalHeader?.classList.remove('hidden');
     };


### PR DESCRIPTION
## Summary
- simplify user profile rendering to place avatar, username, and logout form within single flex container
- add flex gap and nowrap behavior for header items and style user name directly
- show logout hover state in error red

## Testing
- `docker-compose up -d --build` *(fails: Couldn't find env file: /workspace/myfirstapp/.env)*
- `docker-compose restart web` *(fails: Couldn't find env file: /workspace/myfirstapp/.env)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0dc34c4d08327b324c4b795bc0c64