### PR TITLE
Feat: add AI-generated greeting on hub

### DIFF
--- a/dashboard/ai.py
+++ b/dashboard/ai.py
@@ -1,0 +1,45 @@
+import os
+import logging
+from django.core.cache import cache
+import google.generativeai as genai
+
+logger = logging.getLogger(__name__)
+
+# Configure the Gemini API if possible
+try:
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if api_key:
+        genai.configure(api_key=api_key)
+    else:
+        logger.warning("GOOGLE_API_KEY environment variable not set. AI features will be disabled.")
+except Exception as e:
+    logger.warning(f"Could not configure GoogleGenAI: {e}")
+
+
+def generate_greeting(name: str) -> str:
+    """Return a personalized greeting for the given user name.
+
+    Results are cached to avoid excessive API requests.
+    """
+    cache_key = f"ai_greeting:{name}"
+    greeting = cache.get(cache_key)
+    if greeting:
+        return greeting
+
+    # Fallback if API key isn't configured
+    if not os.environ.get("GOOGLE_API_KEY"):
+        greeting = f"Welcome back, {name}!"
+        cache.set(cache_key, greeting, 3600)
+        return greeting
+
+    try:
+        model = genai.GenerativeModel("gemini-1.5-flash")
+        prompt = f"Craft a short, warm greeting for a user named {name}."
+        response = model.generate_content(prompt)
+        greeting = response.text.strip()
+    except Exception as e:
+        logger.warning(f"AI greeting generation failed: {e}")
+        greeting = f"Welcome back, {name}!"
+
+    cache.set(cache_key, greeting, 3600)
+    return greeting

--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
+from django.core.cache import cache
+from unittest.mock import patch
+import os
 
 from .models import Container
 
@@ -18,3 +21,29 @@ class ContainersListViewTests(TestCase):
         self.client.login(username="tester", password="pass123")
         response = self.client.get(reverse('dashboard:containers_list'))
         self.assertContains(response, "Test Container")
+
+
+class HubViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass123")
+
+    @patch('dashboard.views.generate_greeting', return_value="Hello tester!")
+    def test_hub_view_uses_ai_greeting(self, mock_greeting):
+        self.client.login(username="tester", password="pass123")
+        response = self.client.get(reverse('dashboard:hub'))
+        self.assertContains(response, "Hello tester!")
+        mock_greeting.assert_called_once_with("tester")
+
+
+class GenerateGreetingCacheTests(TestCase):
+    @patch.dict(os.environ, {"GOOGLE_API_KEY": "test"})
+    @patch('dashboard.ai.genai.GenerativeModel')
+    def test_generate_greeting_cached(self, mock_model):
+        mock_instance = mock_model.return_value
+        mock_instance.generate_content.return_value.text = "Hi Bob!"
+        cache.clear()
+        from dashboard.ai import generate_greeting
+
+        generate_greeting("Bob")
+        generate_greeting("Bob")
+        mock_instance.generate_content.assert_called_once()

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,12 +1,16 @@
 from django.shortcuts import render, redirect
 
 from .models import Container
+from .ai import generate_greeting
 
 def hub_view(request):
     """Render the hub page."""
     if not request.user.is_authenticated:
         return redirect('login')
-    return render(request, 'dashboard/hub.html')
+    name = request.user.first_name or request.user.username
+    greeting = generate_greeting(name)
+    context = {"greeting": greeting}
+    return render(request, 'dashboard/hub.html', context)
 
 
 def settings_view(request):

--- a/templates/dashboard/hub.html
+++ b/templates/dashboard/hub.html
@@ -6,7 +6,7 @@
         <a href="{% url 'dashboard:settings' %}" class="settings-btn" aria-label="Settings">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
         </a>
-        <h1 class="hub-title">Welcome Back</h1>
+        <h1 class="hub-title">{{ greeting }}</h1>
         <p class="hub-subtitle">Select a container to start a conversation</p>
         <div id="container-grid" class="container-grid"></div>
     </div>


### PR DESCRIPTION
## Summary
- generate personalized greeting using Gemini AI with caching
- pass greeting to hub template and render dynamically
- add tests for view integration and caching

## Testing
- `docker-compose restart web` *(fails: command not found)*
- `docker-compose exec web pytest` *(fails: command not found)*
- `python manage.py test dashboard.tests.HubViewTests dashboard.tests.GenerateGreetingCacheTests dashboard.tests.ContainersListViewTests`


------
https://chatgpt.com/codex/tasks/task_e_68a0df9f192c832780e49a3f6a06cb9b