### PR TITLE
Fix login page hidden by missing page load script

### DIFF
--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -57,3 +57,11 @@
     </main>
 </div>
 {% endblock %}
+
+{% block scripts %}
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        document.body.classList.add('page-loaded');
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- ensure login template triggers `page-loaded` class so styles apply and content becomes visible

## Testing
- `docker-compose exec web pytest` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0e1ebfd5c8327b156435550b3aa00