### PR TITLE
Add start target and migration instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
 # Makefile for common project tasks
 
-.PHONY: docs
+.PHONY: docs start help
 
 docs:
 	@echo "Building Sphinx documentation..."
 	@cd docs && make html
 	@echo "Documentation built in docs/_build/html"
 
+start:
+	@echo "Building containers and applying migrations..."
+	@docker-compose up --build -d
+	@docker-compose exec web python manage.py makemigrations dashboard
+	@docker-compose exec web python manage.py migrate
+
 help:
 	@echo "Available commands:"
 	@echo "  make docs    - Build the Sphinx documentation."
+	@echo "  make start   - Build containers and run migrations."

--- a/README.md
+++ b/README.md
@@ -76,7 +76,21 @@ Use Docker Compose to build the container images and start the application.
 ```bash
 docker-compose up --build
 ```
-The application will now be running at **http://localhost:8080**. The startup command will automatically handle project setup and database migrations for you.
+
+After the containers start, apply the database migrations:
+
+```bash
+docker-compose exec web python manage.py makemigrations dashboard
+docker-compose exec web python manage.py migrate
+```
+
+You can run all of the above steps at once using the Makefile:
+
+```bash
+make start
+```
+
+Once migrations finish, the application will be running at **http://localhost:8080**.
 
 ### Step 4: Log In!
 


### PR DESCRIPTION
## Summary
- add `make start` target to build containers and run migrations
- document manual migration commands and new Makefile helper

## Testing
- `make start` *(fails: docker-compose: No such file or directory)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ea407e0483279bdbdae6ea10c592