### PR TITLE
Fix: adjust SSO provider button layout

### DIFF
--- a/static/css/login.css
+++ b/static/css/login.css
@@ -44,51 +44,6 @@
     margin-top: 0.5rem;
 }
 
-/* New SSO Button Styles */
-.sso-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 1.5rem;
-}
-
-.sso-provider-btn {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    
-    background-color: #ffffff;
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
-    padding: 0.75rem;
-    width: 140px;
-    height: 120px;
-    
-    cursor: pointer;
-    transition: all 0.2s ease-in-out;
-    font-family: var(--font-secondary);
-    
-    color: inherit;
-    text-align: center;
-}
-
-.sso-provider-btn:hover {
-    border-color: #c0c0c0;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    transform: translateY(-2px);
-    text-decoration: none;
-}
-
-.sso-provider-btn .sso-logo {
-    width: 48px;
-    height: 48px;
-}
-
-.sso-provider-btn .sso-provider-text {
-    font-size: 0.8rem;
-    color: #333;
-    font-weight: 500;
-}
+/* SSO button styles moved to main.css */
 
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -13,3 +13,57 @@
 .portal-header .site-logo {
     margin: 0 1rem 0 0;
 }
+
+/* SSO Button Layout Adjustments */
+.sso-buttons {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+}
+
+.sso-provider-btn {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+
+    background-color: #ffffff;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 0.75rem 1.5rem;
+    width: auto;
+    height: 48px;
+
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    font-family: var(--font-secondary);
+
+    color: inherit;
+    text-align: center;
+}
+
+.sso-provider-btn:hover,
+.sso-provider-btn:focus {
+    border-color: #c0c0c0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    transform: translateY(-2px);
+    text-decoration: none;
+}
+
+.sso-provider-btn:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+.sso-provider-btn .sso-logo {
+    width: 48px;
+    height: 48px;
+}
+
+.sso-provider-btn .sso-provider-text {
+    font-size: 0.8rem;
+    color: #333;
+    font-weight: 500;
+}


### PR DESCRIPTION
## Summary
- lay out SSO provider buttons horizontally with flexbox and rectangular sizing
- allow SSO button container to wrap for better spacing
- maintain hover and focus accessibility cues

## Testing
- `docker-compose restart web` *(fails: command not found)*
- `docker-compose exec web pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ef1a412483279ba1a57f020d2278