### PR TITLE
Feat: expose container config API

### DIFF
--- a/dashboard/api_urls.py
+++ b/dashboard/api_urls.py
@@ -2,12 +2,13 @@
 
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .api_views import ContainerViewSet, CurrentUserView
+from .api_views import ContainerViewSet, CurrentUserView, ContainerConfigView
 
 router = DefaultRouter()
 router.register(r'containers', ContainerViewSet, basename='container')
 
 urlpatterns = [
     path('me/', CurrentUserView.as_view(), name='current-user'),
+    path('container-configs/', ContainerConfigView.as_view(), name='container-configs'),
     path('', include(router.urls)),
 ]

--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -2,7 +2,7 @@
 
 from rest_framework import serializers
 from django.contrib.auth.models import User
-from .models import Container, UserProfile
+from .models import Container, UserProfile, ContainerConfig
 
 class UserSerializer(serializers.ModelSerializer):
     full_name = serializers.CharField(source='get_full_name', read_only=True)
@@ -33,3 +33,17 @@ class ContainerSerializer(serializers.ModelSerializer):
             'created_at',
         ]
         read_only_fields = ['owner', 'created_at']
+
+
+class ContainerConfigSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ContainerConfig
+        fields = [
+            'key',
+            'name',
+            'icon',
+            'route',
+            'allowed_roles',
+            'is_active',
+            'order',
+        ]

--- a/dashboard/tests/test_container_config_view.py
+++ b/dashboard/tests/test_container_config_view.py
@@ -1,0 +1,53 @@
+from django.urls import reverse
+from django.contrib.auth.models import User, Group
+from rest_framework.test import APITestCase
+
+from dashboard.models import ContainerConfig
+
+
+class TestContainerConfigView(APITestCase):
+    def setUp(self):
+        self.group_admin = Group.objects.create(name="admin")
+        self.group_user = Group.objects.create(name="user")
+        self.user = User.objects.create_user(username="tester", password="pass123")
+        self.user.groups.add(self.group_admin)
+
+        ContainerConfig.objects.create(
+            key="public",
+            name="Public",
+            route="/public",
+            allowed_roles=[],
+            is_active=True,
+            order=1,
+        )
+        ContainerConfig.objects.create(
+            key="admin",
+            name="Admin Only",
+            route="/admin",
+            allowed_roles=["admin"],
+            is_active=True,
+            order=2,
+        )
+        ContainerConfig.objects.create(
+            key="user",
+            name="User Only",
+            route="/user",
+            allowed_roles=["user"],
+            is_active=True,
+            order=3,
+        )
+        ContainerConfig.objects.create(
+            key="inactive",
+            name="Inactive",
+            route="/inactive",
+            allowed_roles=["admin"],
+            is_active=False,
+            order=4,
+        )
+
+    def test_returns_configs_for_user_groups(self):
+        self.client.login(username="tester", password="pass123")
+        response = self.client.get(reverse('container-configs'))
+        self.assertEqual(response.status_code, 200)
+        names = [cfg['name'] for cfg in response.json()]
+        self.assertEqual(names, ["Public", "Admin Only"])


### PR DESCRIPTION
## Summary
- add ContainerConfigSerializer and ContainerConfigView
- expose /api/container-configs/ endpoint
- test config visibility by user group

## Testing
- `docker-compose restart web` *(fails: command not found)*
- `SECRET_KEY=test DATABASE_URL=sqlite:///:memory: REDIS_URL=redis://localhost:6379/1 python manage.py test dashboard.tests.test_container_config_view`

------
https://chatgpt.com/codex/tasks/task_e_68a0f7dfbe188327a920e9a54ae0c8ff