### PR TITLE
feat: load container configs on hub page

### DIFF
--- a/dashboard/tests/test_container_config_view.py
+++ b/dashboard/tests/test_container_config_view.py
@@ -15,6 +15,7 @@ class TestContainerConfigView(APITestCase):
         ContainerConfig.objects.create(
             key="public",
             name="Public",
+            icon="public-icon",
             route="/public",
             allowed_roles=[],
             is_active=True,
@@ -23,6 +24,7 @@ class TestContainerConfigView(APITestCase):
         ContainerConfig.objects.create(
             key="admin",
             name="Admin Only",
+            icon="admin-icon",
             route="/admin",
             allowed_roles=["admin"],
             is_active=True,
@@ -31,6 +33,7 @@ class TestContainerConfigView(APITestCase):
         ContainerConfig.objects.create(
             key="user",
             name="User Only",
+            icon="user-icon",
             route="/user",
             allowed_roles=["user"],
             is_active=True,
@@ -39,6 +42,7 @@ class TestContainerConfigView(APITestCase):
         ContainerConfig.objects.create(
             key="inactive",
             name="Inactive",
+            icon="inactive-icon",
             route="/inactive",
             allowed_roles=["admin"],
             is_active=False,
@@ -49,5 +53,10 @@ class TestContainerConfigView(APITestCase):
         self.client.login(username="tester", password="pass123")
         response = self.client.get(reverse('container-configs'))
         self.assertEqual(response.status_code, 200)
-        names = [cfg['name'] for cfg in response.json()]
+        configs = response.json()
+        names = [cfg['name'] for cfg in configs]
+        routes = [cfg['route'] for cfg in configs]
+        icons = [cfg['icon'] for cfg in configs]
         self.assertEqual(names, ["Public", "Admin Only"])
+        self.assertEqual(routes, ["/public", "/admin"])
+        self.assertEqual(icons, ["public-icon", "admin-icon"])

--- a/src/pages/hub.ts
+++ b/src/pages/hub.ts
@@ -1,4 +1,4 @@
-import { Container } from "../types";
+import { Container, ContainerConfig } from "../types";
 
 export interface HubPageCallbacks {
     showPage: (page: any) => void;
@@ -24,6 +24,34 @@ export const initHubPage = (cb: HubPageCallbacks) => {
     const containerIconSelector = document.getElementById('container-icon-selector');
     const containerGrid = document.getElementById('container-grid');
     const containerList = document.getElementById('container-list');
+
+    const renderContainerConfigs = (configs: ContainerConfig[]) => {
+        if (!containerGrid) return;
+        containerGrid.innerHTML = '';
+        configs.forEach(cfg => {
+            const card = document.createElement('a');
+            card.className = 'container-card';
+            card.href = cfg.route;
+            card.innerHTML = `
+                <div class="container-icon">${cfg.icon}</div>
+                <h2 class="container-title">${cfg.name}</h2>
+            `;
+            containerGrid.appendChild(card);
+        });
+    };
+
+    const fetchContainerConfigs = async () => {
+        try {
+            const res = await fetch('/api/container-configs/');
+            if (!res.ok) throw new Error('Failed to fetch container configs');
+            const data: ContainerConfig[] = await res.json();
+            renderContainerConfigs(data);
+        } catch (err) {
+            console.error('Error fetching container configs:', err);
+        }
+    };
+
+    fetchContainerConfigs();
 
     settingsBtn?.addEventListener('click', () => cb.showPage('settings'));
     addContainerBtn?.addEventListener('click', cb.openAddContainerModal);

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,4 +28,11 @@ export interface Container {
     accessControl: string[];
 }
 
+export interface ContainerConfig {
+    key: string;
+    name: string;
+    icon: string | null;
+    route: string;
+}
+
 export type ChatHistory = { role: 'user' | 'model'; text: string }[];


### PR DESCRIPTION
## Summary
- fetch container configs on hub page and render cards
- add ContainerConfig type definition
- test container config API for icon and route fields

## Testing
- `docker-compose restart web` *(fails: command not found)*
- `docker-compose exec web pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fb6483548327a2d86d880525fcb7