### PR TITLE
Add API tests verifying container config access by group

### DIFF
--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -1,11 +1,13 @@
 from django.test import TestCase
 from django.urls import reverse
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.core.cache import cache
 from unittest.mock import patch
 import os
 
-from .models import Container, SiteBranding
+from rest_framework.test import APITestCase
+
+from .models import Container, SiteBranding, ContainerConfig
 from .context_processors import site_branding
 
 
@@ -55,4 +57,61 @@ class SiteBrandingContextProcessorTests(TestCase):
         branding = SiteBranding.objects.create()
         context = site_branding(None)
         self.assertEqual(context["site_branding"], branding)
+
+
+class ContainerConfigAPITests(APITestCase):
+    def setUp(self):
+        self.admin_group = Group.objects.create(name="admin")
+        self.user_group = Group.objects.create(name="user")
+        self.user = User.objects.create_user(username="tester", password="pass123")
+        self.user.groups.add(self.admin_group)
+
+        ContainerConfig.objects.create(
+            key="public",
+            name="Public",
+            icon="public-icon",
+            route="/public",
+            allowed_roles=[],
+            is_active=True,
+            order=1,
+        )
+        ContainerConfig.objects.create(
+            key="admin",
+            name="Admin Only",
+            icon="admin-icon",
+            route="/admin",
+            allowed_roles=["admin"],
+            is_active=True,
+            order=2,
+        )
+        ContainerConfig.objects.create(
+            key="user",
+            name="User Only",
+            icon="user-icon",
+            route="/user",
+            allowed_roles=["user"],
+            is_active=True,
+            order=3,
+        )
+        ContainerConfig.objects.create(
+            key="inactive",
+            name="Inactive",
+            icon="inactive-icon",
+            route="/inactive",
+            allowed_roles=["admin"],
+            is_active=False,
+            order=4,
+        )
+
+    def test_user_only_sees_configs_for_their_groups(self):
+        self.client.login(username="tester", password="pass123")
+        response = self.client.get(reverse("container-configs"))
+        self.assertEqual(response.status_code, 200)
+        configs = response.json()
+        names = [cfg["name"] for cfg in configs]
+        routes = [cfg["route"] for cfg in configs]
+        icons = [cfg["icon"] for cfg in configs]
+        self.assertEqual(names, ["Public", "Admin Only"])
+        self.assertEqual(routes, ["/public", "/admin"])
+        self.assertEqual(icons, ["public-icon", "admin-icon"])
 


### PR DESCRIPTION
## Summary
- test: ensure container-configs API returns only configs allowed for the user's group

## Testing
- `DATABASE_URL=sqlite:///test.db python manage.py test dashboard.tests.ContainerConfigAPITests`


------
https://chatgpt.com/codex/tasks/task_e_68a0fccd7aa88327bb88367eabf4ff2f