### PR TITLE
Feat: load cookie and CSRF settings from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ DEBUG=True
 SECRET_KEY='django-insecure-example-key-for-local-dev'
 ALLOWED_HOSTS=127.0.0.1,localhost
 
+CSRF_TRUSTED_ORIGINS=http://localhost,http://127.0.0.1
+SESSION_COOKIE_SECURE=False
+CSRF_COOKIE_SECURE=False
+SESSION_COOKIE_SAMESITE=Lax
+
 # Database URL
 # The default is set to connect to the PostgreSQL container from docker-compose.
 DATABASE_URL=postgres://user:password@db:5432/ai_portal

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -25,6 +25,14 @@ DEBUG = env('DEBUG')
 
 ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=['localhost', '127.0.0.1'])
 
+CSRF_TRUSTED_ORIGINS = env.list(
+    'CSRF_TRUSTED_ORIGINS', default=['http://localhost', 'http://127.0.0.1']
+)
+
+SESSION_COOKIE_SECURE = env.bool('SESSION_COOKIE_SECURE', default=False)
+CSRF_COOKIE_SECURE = env.bool('CSRF_COOKIE_SECURE', default=False)
+SESSION_COOKIE_SAMESITE = env('SESSION_COOKIE_SAMESITE', default='Lax')
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
## Summary
- configure CSRF trusted origins and cookie security settings via environment variables
- document default cookie and CSRF environment variables in `.env.example`

## Testing
- `docker-compose up -d` *(fails: Error while fetching server API version: FileNotFoundError(2, 'No such file or directory'))*
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a13f2c7830832789dedd586f1999e1