### PR TITLE
Feat: add resilient Gemini greeting

### DIFF
--- a/dashboard/ai.py
+++ b/dashboard/ai.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import time
 from django.core.cache import cache
 import google.generativeai as genai
 
@@ -14,6 +15,31 @@ try:
         logger.warning("GOOGLE_API_KEY environment variable not set. AI features will be disabled.")
 except Exception as e:
     logger.warning(f"Could not configure GoogleGenAI: {e}")
+
+
+def call_gemini(prompt: str, model_name: str = "gemini-1.5-flash", *, timeout: int = 10, max_retries: int = 3) -> str:
+    """Call Gemini with retries and timeout.
+
+    Raises the last exception if all retries fail.
+    """
+
+    if not os.environ.get("GOOGLE_API_KEY"):
+        raise RuntimeError("Gemini AI not configured")
+
+    delay = 1
+    for attempt in range(max_retries):
+        try:
+            model = genai.GenerativeModel(model_name)
+            response = model.generate_content(prompt, request_options={"timeout": timeout})
+            return response.text.strip()
+        except Exception as e:
+            logger.warning(
+                "Gemini call failed (attempt %d/%d): %s", attempt + 1, max_retries, e
+            )
+            if attempt == max_retries - 1:
+                raise
+            time.sleep(delay)
+            delay *= 2
 
 
 def generate_greeting(name: str) -> str:
@@ -32,11 +58,9 @@ def generate_greeting(name: str) -> str:
         cache.set(cache_key, greeting, 3600)
         return greeting
 
+    prompt = f"Craft a short, warm greeting for a user named {name}."
     try:
-        model = genai.GenerativeModel("gemini-1.5-flash")
-        prompt = f"Craft a short, warm greeting for a user named {name}."
-        response = model.generate_content(prompt)
-        greeting = response.text.strip()
+        greeting = call_gemini(prompt)
     except Exception as e:
         logger.warning(f"AI greeting generation failed: {e}")
         greeting = f"Welcome back, {name}!"

--- a/dashboard/tests/test_ai.py
+++ b/dashboard/tests/test_ai.py
@@ -1,0 +1,38 @@
+import os
+from unittest import mock
+
+import pytest
+
+from dashboard import ai
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    from django.core.cache import cache
+    cache.clear()
+
+
+def test_call_gemini_retries_on_failure(monkeypatch):
+    os.environ["GOOGLE_API_KEY"] = "dummy"
+
+    model_instance = mock.Mock()
+    responses = [TimeoutError("boom"), TimeoutError("boom"), mock.Mock(text="hi")]
+    model_instance.generate_content.side_effect = responses
+
+    monkeypatch.setattr(ai.genai, "GenerativeModel", lambda *a, **k: model_instance)
+
+    sleeps = []
+    monkeypatch.setattr(ai.time, "sleep", lambda s: sleeps.append(s))
+
+    result = ai.call_gemini("hello")
+    assert result == "hi"
+    assert model_instance.generate_content.call_count == 3
+    assert sleeps == [1, 2]
+
+
+def test_generate_greeting_fallback(monkeypatch):
+    os.environ["GOOGLE_API_KEY"] = "dummy"
+    monkeypatch.setattr(ai, "call_gemini", mock.Mock(side_effect=Exception("fail")))
+
+    greeting = ai.generate_greeting("Alice")
+    assert greeting == "Welcome back, Alice!"


### PR DESCRIPTION
## Summary
- retry Gemini calls with timeout and exponential backoff
- fall back to default greeting when Gemini fails
- test greeting retries and fallback behaviour

## Testing
- `docker-compose restart web` *(fails: command not found)*
- `docker-compose exec web pytest` *(fails: command not found)*
- `PYTHONPATH=. DJANGO_SETTINGS_MODULE=portal.settings SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 pytest dashboard/tests/test_ai.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a15dcbef908327bb76dc39caed9f76