### PR TITLE
Feat: add serializer field validation

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -14,6 +14,115 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class ContainerSerializer(serializers.ModelSerializer):
+    MAX_LIST_ITEMS = 20
+    MAX_FUNCTION_PARAMETERS = 10
+    ALLOWED_PARAM_TYPES = {"string", "number", "textarea"}
+
+    def _validate_string_list(self, value, field_name, item_max_length=100):
+        if not isinstance(value, list):
+            raise serializers.ValidationError(f"{field_name} must be a list.")
+        if len(value) > self.MAX_LIST_ITEMS:
+            raise serializers.ValidationError(
+                f"{field_name} cannot contain more than {self.MAX_LIST_ITEMS} items."
+            )
+        for item in value:
+            if not isinstance(item, str):
+                raise serializers.ValidationError(
+                    f"Each entry in {field_name} must be a string."
+                )
+            if len(item) > item_max_length:
+                raise serializers.ValidationError(
+                    f"Entries in {field_name} must be at most {item_max_length} characters."
+                )
+        return value
+
+    def validate_quickQuestions(self, value):
+        return self._validate_string_list(value, "quickQuestions", item_max_length=200)
+
+    def validate_availableModels(self, value):
+        return self._validate_string_list(value, "availableModels")
+
+    def validate_availablePersonas(self, value):
+        return self._validate_string_list(value, "availablePersonas")
+
+    def validate_accessControl(self, value):
+        return self._validate_string_list(value, "accessControl")
+
+    def validate_functions(self, value):
+        if not isinstance(value, list):
+            raise serializers.ValidationError("functions must be a list.")
+        if len(value) > self.MAX_LIST_ITEMS:
+            raise serializers.ValidationError(
+                f"functions cannot contain more than {self.MAX_LIST_ITEMS} items."
+            )
+        for func in value:
+            if not isinstance(func, dict):
+                raise serializers.ValidationError(
+                    "Each function must be an object with the required fields."
+                )
+
+            required_fields = {
+                "id",
+                "name",
+                "description",
+                "icon",
+                "parameters",
+                "promptTemplate",
+                "enabled",
+            }
+            missing = required_fields - func.keys()
+            if missing:
+                raise serializers.ValidationError(
+                    f"Function missing fields: {', '.join(sorted(missing))}."
+                )
+
+            if not isinstance(func["id"], str) or not func["id"]:
+                raise serializers.ValidationError("Function 'id' must be a non-empty string.")
+            if not isinstance(func["name"], str) or not func["name"]:
+                raise serializers.ValidationError("Function 'name' must be a non-empty string.")
+            if not isinstance(func["description"], str):
+                raise serializers.ValidationError("Function 'description' must be a string.")
+            if not isinstance(func["icon"], str):
+                raise serializers.ValidationError("Function 'icon' must be a string.")
+            if not isinstance(func["promptTemplate"], str):
+                raise serializers.ValidationError("Function 'promptTemplate' must be a string.")
+            if not isinstance(func["enabled"], bool):
+                raise serializers.ValidationError("Function 'enabled' must be a boolean.")
+
+            parameters = func.get("parameters")
+            if not isinstance(parameters, list):
+                raise serializers.ValidationError(
+                    "Function 'parameters' must be a list."
+                )
+            if len(parameters) > self.MAX_FUNCTION_PARAMETERS:
+                raise serializers.ValidationError(
+                    f"Function 'parameters' cannot contain more than {self.MAX_FUNCTION_PARAMETERS} items."
+                )
+            for param in parameters:
+                if not isinstance(param, dict):
+                    raise serializers.ValidationError(
+                        "Each parameter must be an object with the required fields."
+                    )
+                param_required = {"name", "type", "description"}
+                missing_param = param_required - param.keys()
+                if missing_param:
+                    raise serializers.ValidationError(
+                        f"Parameter missing fields: {', '.join(sorted(missing_param))}."
+                    )
+
+                if not isinstance(param["name"], str) or not param["name"]:
+                    raise serializers.ValidationError(
+                        "Parameter 'name' must be a non-empty string."
+                    )
+                if param["type"] not in self.ALLOWED_PARAM_TYPES:
+                    raise serializers.ValidationError(
+                        "Parameter 'type' must be one of: string, number, textarea."
+                    )
+                if not isinstance(param["description"], str):
+                    raise serializers.ValidationError(
+                        "Parameter 'description' must be a string."
+                    )
+        return value
     class Meta:
         model = Container
         # Include all new fields to be exposed in the API

--- a/dashboard/tests/test_serializer_validation.py
+++ b/dashboard/tests/test_serializer_validation.py
@@ -1,0 +1,57 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from dashboard.models import Container
+from dashboard.serializers import ContainerSerializer
+
+
+class TestContainerSerializerValidation(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", password="pass")
+        self.container = Container.objects.create(name="Test", owner=self.user)
+
+    def test_valid_quick_questions_and_functions(self):
+        data = {
+            "quickQuestions": ["What is up?", "Another question"],
+            "functions": [
+                {
+                    "id": "func1",
+                    "name": "Func",
+                    "description": "desc",
+                    "icon": "<svg></svg>",
+                    "parameters": [
+                        {"name": "q", "type": "string", "description": "question"}
+                    ],
+                    "promptTemplate": "Hi {{q}}",
+                    "enabled": True,
+                }
+            ],
+        }
+        serializer = ContainerSerializer(instance=self.container, data=data, partial=True)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_invalid_quick_question_type(self):
+        data = {"quickQuestions": ["ok", 123]}
+        serializer = ContainerSerializer(instance=self.container, data=data, partial=True)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("quickQuestions", serializer.errors)
+
+    def test_invalid_function_schema(self):
+        data = {
+            "functions": [
+                {
+                    "id": "func1",
+                    "name": "Func",
+                    "description": "desc",
+                    "icon": "<svg></svg>",
+                    "parameters": [
+                        {"name": "q", "type": "invalid", "description": "question"}
+                    ],
+                    "promptTemplate": "Hi {{q}}",
+                    "enabled": True,
+                }
+            ]
+        }
+        serializer = ContainerSerializer(instance=self.container, data=data, partial=True)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("functions", serializer.errors)


### PR DESCRIPTION
## Summary
- validate quick question, model, persona, and access control lists
- validate function definitions and parameters
- test serializer validation with valid and invalid payloads

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 python manage.py test dashboard.tests.test_container_permissions dashboard.tests.test_container_config_view dashboard.tests.test_serializer_validation`
- `PYTHONPATH=/workspace/myfirstapp SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 DJANGO_SETTINGS_MODULE=portal.settings pytest dashboard/tests/test_ai.py`


------
https://chatgpt.com/codex/tasks/task_e_68a17223e9108327be5559a7ce755b1b