### PR TITLE
Feat: enforce API quota for AI endpoints

### DIFF
--- a/dashboard/api_views.py
+++ b/dashboard/api_views.py
@@ -10,8 +10,9 @@ from rest_framework.views import APIView
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated, BasePermission
-from .models import Container, ContainerConfig
+from .models import Container, ContainerConfig, UserProfile
 from .serializers import ContainerSerializer, UserSerializer, ContainerConfigSerializer
+from .throttles import UserProfileQuotaThrottle
 import google.generativeai as genai
 
 logger = logging.getLogger(__name__)
@@ -25,6 +26,16 @@ try:
         logger.warning("GOOGLE_API_KEY environment variable not set. AI features will be disabled.")
 except Exception as e:
     logger.warning(f"Could not configure GoogleGenAI: {e}")
+
+
+def decrement_api_quota(user):
+    try:
+        profile = UserProfile.objects.get(user=user)
+    except UserProfile.DoesNotExist:
+        return
+    if profile.api_quota > 0:
+        profile.api_quota -= 1
+        profile.save()
 
 
 class CurrentUserView(APIView):
@@ -79,7 +90,7 @@ class ContainerViewSet(viewsets.ModelViewSet):
         container = serializer.save(owner=self.request.user)
         container.members.add(self.request.user)
 
-    def _call_gemini_suggestion(self, prompt):
+    def _call_gemini_suggestion(self, request, prompt):
         if not os.environ.get("GOOGLE_API_KEY"):
             return Response({"error": "Gemini AI not configured on the server"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         try:
@@ -90,23 +101,24 @@ class ContainerViewSet(viewsets.ModelViewSet):
                     response_mime_type="application/json"
                 )
             )
+            decrement_api_quota(request.user)
             return Response(json.loads(response.text))
         except Exception as e:
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=['post'], throttle_classes=[UserProfileQuotaThrottle])
     def suggest_questions(self, request, pk=None):
         container = self.get_object()
         prompt = f"Based on a container named '{container.name}', generate 4 diverse and insightful 'quick questions' a user might ask an AI assistant in this context. Focus on actionable and common queries. Return as a JSON object with a 'suggestions' key containing an array of strings."
-        return self._call_gemini_suggestion(prompt)
+        return self._call_gemini_suggestion(request, prompt)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=['post'], throttle_classes=[UserProfileQuotaThrottle])
     def suggest_personas(self, request, pk=None):
         container = self.get_object()
         prompt = f"Based on a container named '{container.name}', generate 4 creative and distinct 'personas' for an AI assistant. Examples: 'Concise Expert', 'Friendly Guide'. Return as a JSON object with a 'suggestions' key containing an array of strings."
-        return self._call_gemini_suggestion(prompt)
+        return self._call_gemini_suggestion(request, prompt)
     
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=['post'], throttle_classes=[UserProfileQuotaThrottle])
     def generate_function(self, request, pk=None):
         user_request = request.data.get('prompt', '')
         if not user_request:
@@ -125,10 +137,10 @@ class ContainerViewSet(viewsets.ModelViewSet):
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
         """
-        return self._call_gemini_suggestion(prompt)
+        return self._call_gemini_suggestion(request, prompt)
 
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=['post'], throttle_classes=[UserProfileQuotaThrottle])
     def chat(self, request, pk=None):
         container = self.get_object()
         message = request.data.get('message', '')
@@ -155,8 +167,9 @@ class ContainerViewSet(viewsets.ModelViewSet):
                 system_instruction=f"You are an assistant for the {container.name} container. Your persona is {container.selectedPersona}."
             )
             chat = model.start_chat(history=sdk_history)
-            
+
             response = chat.send_message(message)
+            decrement_api_quota(request.user)
 
             return Response({"reply": response.text})
         except Exception as e:

--- a/dashboard/tests/test_api_quota.py
+++ b/dashboard/tests/test_api_quota.py
@@ -1,0 +1,38 @@
+import os
+from unittest.mock import patch, Mock
+
+from django.urls import reverse
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
+
+from dashboard.models import Container, UserProfile
+
+
+class TestAPIQuota(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="u", password="pass")
+        self.container = Container.objects.create(name="C", owner=self.user)
+        self.container.members.add(self.user)
+        self.url = reverse('container-suggest-questions', args=[self.container.id])
+
+    @patch('dashboard.api_views.genai.GenerativeModel')
+    def test_quota_decrements_on_success(self, mock_model):
+        os.environ['GOOGLE_API_KEY'] = 'dummy'
+        instance = mock_model.return_value
+        instance.generate_content.return_value = Mock(text='{}')
+        UserProfile.objects.create(user=self.user, api_quota=2)
+        self.client.login(username="u", password="pass")
+        self.client.post(self.url)
+        profile = UserProfile.objects.get(user=self.user)
+        assert profile.api_quota == 1
+
+    @patch('dashboard.api_views.genai.GenerativeModel')
+    def test_quota_enforced_when_exhausted(self, mock_model):
+        os.environ['GOOGLE_API_KEY'] = 'dummy'
+        instance = mock_model.return_value
+        instance.generate_content.return_value = Mock(text='{}')
+        UserProfile.objects.create(user=self.user, api_quota=0)
+        self.client.login(username="u", password="pass")
+        response = self.client.post(self.url)
+        assert response.status_code == 429
+        assert instance.generate_content.call_count == 0

--- a/dashboard/throttles.py
+++ b/dashboard/throttles.py
@@ -1,0 +1,16 @@
+from rest_framework.throttling import BaseThrottle
+from .models import UserProfile
+
+
+class UserProfileQuotaThrottle(BaseThrottle):
+    """Throttle that blocks requests when a user's API quota is exhausted."""
+
+    def allow_request(self, request, view):
+        user = getattr(request, "user", None)
+        if not user or not user.is_authenticated:
+            return True
+        try:
+            profile = UserProfile.objects.get(user=user)
+        except UserProfile.DoesNotExist:
+            return True
+        return profile.api_quota > 0


### PR DESCRIPTION
## Summary
- throttle AI endpoints based on `UserProfile.api_quota`
- decrement quota on successful AI responses
- test quota consumption and exhaustion handling

## Testing
- `python manage.py test dashboard.tests.test_api_quota`
- `python manage.py test dashboard.tests.test_container_permissions dashboard.tests.test_container_config_view dashboard.tests.test_serializer_validation`


------
https://chatgpt.com/codex/tasks/task_e_68a173ae5d7483279fdac0676f176b8c