### PR TITLE
Feat: background task queue for AI calls

### DIFF
--- a/dashboard/api_urls.py
+++ b/dashboard/api_urls.py
@@ -2,7 +2,7 @@
 
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .api_views import ContainerViewSet, CurrentUserView, ContainerConfigView
+from .api_views import ContainerViewSet, CurrentUserView, ContainerConfigView, TaskStatusView
 
 router = DefaultRouter()
 router.register(r'containers', ContainerViewSet, basename='container')
@@ -10,5 +10,6 @@ router.register(r'containers', ContainerViewSet, basename='container')
 urlpatterns = [
     path('me/', CurrentUserView.as_view(), name='current-user'),
     path('container-configs/', ContainerConfigView.as_view(), name='container-configs'),
+    path('tasks/<str:task_id>/', TaskStatusView.as_view(), name='task-status'),
     path('', include(router.urls)),
 ]

--- a/dashboard/api_views.py
+++ b/dashboard/api_views.py
@@ -1,25 +1,18 @@
-import json
 from rest_framework import viewsets, status
 from rest_framework.views import APIView
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated, BasePermission
-from .models import Container, ContainerConfig, UserProfile
+from .models import Container, ContainerConfig
 from .serializers import ContainerSerializer, UserSerializer, ContainerConfigSerializer
 from .throttles import UserProfileQuotaThrottle
-import google.generativeai as genai
 
 from .ai_service import get_model
+from .tasks import gemini_suggestion_task, chat_task
+from .utils import decrement_api_quota
+from celery.result import AsyncResult
 
 
-def decrement_api_quota(user):
-    try:
-        profile = UserProfile.objects.get(user=user)
-    except UserProfile.DoesNotExist:
-        return
-    if profile.api_quota > 0:
-        profile.api_quota -= 1
-        profile.save()
 
 
 class CurrentUserView(APIView):
@@ -74,31 +67,19 @@ class ContainerViewSet(viewsets.ModelViewSet):
         container = serializer.save(owner=self.request.user)
         container.members.add(self.request.user)
 
-    def _call_gemini_suggestion(self, request, prompt):
-        try:
-            model = get_model('gemini-2.5-flash')
-            response = model.generate_content(
-                prompt,
-                generation_config=genai.types.GenerationConfig(
-                    response_mime_type="application/json"
-                )
-            )
-            decrement_api_quota(request.user)
-            return Response(json.loads(response.text))
-        except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
     @action(detail=True, methods=['post'], throttle_classes=[UserProfileQuotaThrottle])
     def suggest_questions(self, request, pk=None):
         container = self.get_object()
         prompt = f"Based on a container named '{container.name}', generate 4 diverse and insightful 'quick questions' a user might ask an AI assistant in this context. Focus on actionable and common queries. Return as a JSON object with a 'suggestions' key containing an array of strings."
-        return self._call_gemini_suggestion(request, prompt)
+        task = gemini_suggestion_task.delay(request.user.id, prompt)
+        return Response({"task_id": task.id}, status=status.HTTP_202_ACCEPTED)
 
     @action(detail=True, methods=['post'], throttle_classes=[UserProfileQuotaThrottle])
     def suggest_personas(self, request, pk=None):
         container = self.get_object()
         prompt = f"Based on a container named '{container.name}', generate 4 creative and distinct 'personas' for an AI assistant. Examples: 'Concise Expert', 'Friendly Guide'. Return as a JSON object with a 'suggestions' key containing an array of strings."
-        return self._call_gemini_suggestion(request, prompt)
+        task = gemini_suggestion_task.delay(request.user.id, prompt)
+        return Response({"task_id": task.id}, status=status.HTTP_202_ACCEPTED)
     
     @action(detail=True, methods=['post'], throttle_classes=[UserProfileQuotaThrottle])
     def generate_function(self, request, pk=None):
@@ -119,7 +100,8 @@ class ContainerViewSet(viewsets.ModelViewSet):
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>
         """
-        return self._call_gemini_suggestion(request, prompt)
+        task = gemini_suggestion_task.delay(request.user.id, prompt)
+        return Response({"task_id": task.id}, status=status.HTTP_202_ACCEPTED)
 
 
     @action(detail=True, methods=['post'], throttle_classes=[UserProfileQuotaThrottle])
@@ -131,27 +113,15 @@ class ContainerViewSet(viewsets.ModelViewSet):
         if not message:
             return Response({"error": "Message is required"}, status=status.HTTP_400_BAD_REQUEST)
 
-        try:
-            # Convert client history to the format required by the Python SDK
-            sdk_history = []
-            for item in history_from_client:
-                role = 'model' if item.get('role') == 'model' else 'user'
-                sdk_history.append({
-                    'role': role,
-                    'parts': [item.get('text', '')]
-                })
+        task = chat_task.delay(request.user.id, container.id, message, history_from_client)
+        return Response({"task_id": task.id}, status=status.HTTP_202_ACCEPTED)
 
-            model = get_model(
-                container.selectedModel,
-                system_instruction=(
-                    f"You are an assistant for the {container.name} container. Your persona is {container.selectedPersona}."
-                ),
-            )
-            chat = model.start_chat(history=sdk_history)
 
-            response = chat.send_message(message)
-            decrement_api_quota(request.user)
+class TaskStatusView(APIView):
+    permission_classes = [IsAuthenticated]
 
-            return Response({"reply": response.text})
-        except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    def get(self, request, task_id):
+        result = AsyncResult(task_id)
+        if result.successful():
+            return Response({"status": result.status, "result": result.result})
+        return Response({"status": result.status})

--- a/dashboard/tasks.py
+++ b/dashboard/tasks.py
@@ -1,0 +1,42 @@
+import json
+from celery import shared_task
+import google.generativeai as genai
+from django.contrib.auth import get_user_model
+
+from .ai_service import get_model
+from .utils import decrement_api_quota
+from .models import Container
+
+
+@shared_task
+def gemini_suggestion_task(user_id, prompt):
+    user = get_user_model().objects.get(pk=user_id)
+    model = get_model('gemini-2.5-flash')
+    response = model.generate_content(
+        prompt,
+        generation_config=genai.types.GenerationConfig(
+            response_mime_type="application/json"
+        ),
+    )
+    decrement_api_quota(user)
+    return json.loads(response.text)
+
+
+@shared_task
+def chat_task(user_id, container_id, message, history_from_client):
+    container = Container.objects.get(pk=container_id)
+    sdk_history = []
+    for item in history_from_client:
+        role = 'model' if item.get('role') == 'model' else 'user'
+        sdk_history.append({'role': role, 'parts': [item.get('text', '')]})
+    model = get_model(
+        container.selectedModel,
+        system_instruction=(
+            f"You are an assistant for the {container.name} container. Your persona is {container.selectedPersona}."
+        ),
+    )
+    chat = model.start_chat(history=sdk_history)
+    response = chat.send_message(message)
+    user = get_user_model().objects.get(pk=user_id)
+    decrement_api_quota(user)
+    return {"reply": response.text}

--- a/dashboard/tests/test_task_status.py
+++ b/dashboard/tests/test_task_status.py
@@ -1,0 +1,22 @@
+from django.urls import reverse
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
+from unittest.mock import patch, MagicMock
+
+
+class TestTaskStatus(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="u", password="p")
+
+    @patch('dashboard.api_views.AsyncResult')
+    def test_task_status_endpoint(self, mock_async):
+        mock_result = MagicMock()
+        mock_result.status = 'SUCCESS'
+        mock_result.result = {'data': 'ok'}
+        mock_async.return_value = mock_result
+        self.client.login(username="u", password="p")
+        url = reverse('task-status', args=['abc'])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['status'], 'SUCCESS')
+        self.assertEqual(response.data['result'], {'data': 'ok'})

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -1,0 +1,11 @@
+from .models import UserProfile
+
+
+def decrement_api_quota(user):
+    try:
+        profile = UserProfile.objects.get(user=user)
+    except UserProfile.DoesNotExist:
+        return
+    if profile.api_quota > 0:
+        profile.api_quota -= 1
+        profile.save()

--- a/portal/__init__.py
+++ b/portal/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/portal/celery.py
+++ b/portal/celery.py
@@ -1,0 +1,10 @@
+import os
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'portal.settings')
+
+app = Celery('portal')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()
+
+__all__ = ('app',)

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -154,6 +154,13 @@ CHANNEL_LAYERS = {
     },
 }
 
+# Celery configuration
+CELERY_BROKER_URL = env('REDIS_URL')
+CELERY_RESULT_BACKEND = env('REDIS_URL')
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+
 # Microsoft Authentication Settings
 MS_CLIENT_ID = env('MS_CLIENT_ID', default=None)
 MS_CLIENT_SECRET = env('MS_CLIENT_SECRET', default=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,10 @@ djangorestframework==3.15.1
 channels==4.0.0
 channels-redis==4.2.0
 
+# Task Queue
+celery==5.4.0
+redis==5.0.1
+
 # AI & Machine Learning
 google-generativeai==0.7.1
 # The following are for RAG features described in agents.md, but not yet implemented.


### PR DESCRIPTION
## Summary
- integrate Celery with Redis for async processing
- offload AI requests from ContainerViewSet to Celery tasks
- add task status endpoint and update tests for async behavior

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 DJANGO_SETTINGS_MODULE=portal.settings pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1782c68f0832781e2cffc356d0045