### PR TITLE
Add tests for Gemini container actions

### DIFF
--- a/dashboard/tests/test_ai_actions.py
+++ b/dashboard/tests/test_ai_actions.py
@@ -1,0 +1,87 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+from django.urls import reverse
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
+
+from dashboard.models import Container
+
+
+class TestGeminiActions(APITestCase):
+    def setUp(self):
+        os.environ['GOOGLE_API_KEY'] = 'dummy'
+        self.owner = User.objects.create_user(username='owner', password='pass')
+        self.other = User.objects.create_user(username='other', password='pass')
+        self.container = Container.objects.create(name='C', owner=self.owner)
+        self.container.members.add(self.owner, self.other)
+
+    @patch('dashboard.tasks.genai.GenerativeModel')
+    @patch('dashboard.tasks.gemini_suggestion_task.delay')
+    def test_suggest_questions_success(self, mock_delay, mock_model):
+        mock_delay.return_value = SimpleNamespace(id='t1')
+        self.client.login(username='owner', password='pass')
+        url = reverse('container-suggest-questions', args=[self.container.id])
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 202)
+        self.assertEqual(resp.data['task_id'], 't1')
+        mock_delay.assert_called_once()
+
+    @patch('dashboard.tasks.genai.GenerativeModel')
+    @patch('dashboard.tasks.gemini_suggestion_task.delay')
+    def test_suggest_personas_success(self, mock_delay, mock_model):
+        mock_delay.return_value = SimpleNamespace(id='t2')
+        self.client.login(username='owner', password='pass')
+        url = reverse('container-suggest-personas', args=[self.container.id])
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 202)
+        self.assertEqual(resp.data['task_id'], 't2')
+        mock_delay.assert_called_once()
+
+    @patch('dashboard.tasks.genai.GenerativeModel')
+    @patch('dashboard.tasks.gemini_suggestion_task.delay')
+    def test_generate_function_success_and_error(self, mock_delay, mock_model):
+        mock_delay.return_value = SimpleNamespace(id='t3')
+        self.client.login(username='owner', password='pass')
+        url = reverse('container-generate-function', args=[self.container.id])
+        resp = self.client.post(url, {'prompt': 'do x'}, format='json')
+        self.assertEqual(resp.status_code, 202)
+        self.assertEqual(resp.data['task_id'], 't3')
+        mock_delay.assert_called_once()
+
+        mock_delay.reset_mock()
+        resp = self.client.post(url, {}, format='json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('error', resp.data)
+        mock_delay.assert_not_called()
+
+    @patch('dashboard.tasks.genai.GenerativeModel')
+    @patch('dashboard.tasks.chat_task.delay')
+    def test_chat_success_and_error(self, mock_delay, mock_model):
+        mock_delay.return_value = SimpleNamespace(id='t4')
+        self.client.login(username='owner', password='pass')
+        url = reverse('container-chat', args=[self.container.id])
+        resp = self.client.post(url, {'message': 'hi', 'history': []}, format='json')
+        self.assertEqual(resp.status_code, 202)
+        self.assertEqual(resp.data['task_id'], 't4')
+        mock_delay.assert_called_once()
+
+        mock_delay.reset_mock()
+        resp = self.client.post(url, {}, format='json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('error', resp.data)
+        mock_delay.assert_not_called()
+
+    def test_unauthorized_access_rejected(self):
+        # test each restricted action for non-owner
+        self.client.login(username='other', password='pass')
+        actions = [
+            ('container-suggest-questions', {}),
+            ('container-suggest-personas', {}),
+            ('container-chat', {'message': 'hi'}),
+        ]
+        for name, data in actions:
+            url = reverse(name, args=[self.container.id])
+            resp = self.client.post(url, data, format='json')
+            self.assertEqual(resp.status_code, 403)


### PR DESCRIPTION
## Summary
- add comprehensive tests for Gemini-backed container actions
- verify error handling for missing prompts/messages
- ensure non-owners cannot trigger AI actions

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 python manage.py test dashboard.tests.test_ai_actions -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68a17aef247c8327ba9d2251c1320791