### PR TITLE
Fix case-insensitive email login

### DIFF
--- a/users/backends.py
+++ b/users/backends.py
@@ -14,8 +14,8 @@ class EmailOrUsernameBackend(BaseBackend):
             user = UserModel.objects.get(username=username)
         except UserModel.DoesNotExist:
             try:
-                # Try to fetch the user by email
-                user = UserModel.objects.get(email=username)
+                # Try to fetch the user by email (case-insensitive)
+                user = UserModel.objects.get(email__iexact=username)
             except UserModel.DoesNotExist:
                 # Neither username nor email matched
                 return None

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
+from django.contrib.auth import authenticate, get_user_model
+from unittest.mock import patch
 
 class LoginRedirectTests(TestCase):
     def setUp(self):
@@ -12,3 +14,28 @@ class LoginRedirectTests(TestCase):
             'password': 'pass123',
         })
         self.assertRedirects(response, reverse('dashboard:hub'))
+
+
+class AuthBackendTests(TestCase):
+    def setUp(self):
+        UserModel = get_user_model()
+        self.user = UserModel.objects.create_user(
+            username='tester',
+            email='test@example.com',
+            password='irrelevant'
+        )
+
+    @patch('django.contrib.auth.models.User.check_password', return_value=True)
+    def test_authenticate_with_username(self, mock_check_password):
+        user = authenticate(username='tester', password='secret')
+        self.assertEqual(user, self.user)
+
+    @patch('django.contrib.auth.models.User.check_password', return_value=True)
+    def test_authenticate_with_email_case_insensitive(self, mock_check_password):
+        user = authenticate(username='TEST@EXAMPLE.COM', password='secret')
+        self.assertEqual(user, self.user)
+
+    @patch('django.contrib.auth.models.User.check_password', return_value=False)
+    def test_authentication_failed(self, mock_check_password):
+        user = authenticate(username='tester', password='wrong')
+        self.assertIsNone(user)


### PR DESCRIPTION
## Summary
- allow EmailOrUsernameBackend to match email addresses case-insensitively
- add tests for username login, email login, and failed authentication

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 python manage.py test users`

------
https://chatgpt.com/codex/tasks/task_e_68a17ec767388327a08249a923b8d5cb