### PR TITLE
feat: sanitize container icon fields

### DIFF
--- a/dashboard/tests/test_icon_sanitization.py
+++ b/dashboard/tests/test_icon_sanitization.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from dashboard.models import Container, ContainerConfig
+
+
+class IconSanitizationTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass123")
+
+    def test_container_icon_sanitized(self):
+        svg = '<svg onload="alert(1)"><script>alert(1)</script><rect width="10" height="10" onclick="doBad()" /></svg>'
+        container = Container.objects.create(name="Test", icon=svg, owner=self.user)
+        self.assertNotIn("script", container.icon)
+        self.assertNotIn("onload", container.icon)
+        self.assertNotIn("onclick", container.icon)
+        self.assertIn("rect", container.icon)
+
+    def test_container_config_icon_sanitized(self):
+        svg = '<svg><rect width="10" height="10" /><script>alert(1)</script></svg>'
+        cfg = ContainerConfig.objects.create(key="test", name="Test", icon=svg, route="/test")
+        self.assertNotIn("script", cfg.icon)

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ msal==1.28.0
 # Utilities
 Pillow==11.3.0
 requests==2.32.3
+bleach==6.2.0


### PR DESCRIPTION
## Summary
- sanitize `Container.icon` and `ContainerConfig.icon` using `bleach`
- add `bleach` dependency
- test that malicious SVG snippets are cleaned

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 python manage.py test dashboard.tests.test_icon_sanitization dashboard.tests.test_container_config_view`


------
https://chatgpt.com/codex/tasks/task_e_68a18044c0b08327bf9d5dc1c3f6fe72