### PR TITLE
Chore: add docstrings and type annotations

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,10 +1,12 @@
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render, redirect
 
-from .models import Container
 from .ai import generate_greeting
+from .models import Container
 
-def hub_view(request):
-    """Render the hub page."""
+
+def hub_view(request: HttpRequest) -> HttpResponse:
+    """Render the hub page for the authenticated user."""
     if not request.user.is_authenticated:
         return redirect('login')
     name = request.user.first_name or request.user.username
@@ -13,22 +15,22 @@ def hub_view(request):
     return render(request, 'dashboard/hub.html', context)
 
 
-def settings_view(request):
+def settings_view(request: HttpRequest) -> HttpResponse:
     """Render the settings page."""
     if not request.user.is_authenticated:
         return redirect('login')
     return render(request, 'dashboard/settings.html')
 
 
-def settings_detail_view(request, container_id):
-    """Render the settings detail page for a container."""
+def settings_detail_view(request: HttpRequest, container_id: int) -> HttpResponse:
+    """Render the settings detail page for a specific container."""
     if not request.user.is_authenticated:
         return redirect('login')
     context = {"container_id": container_id}
     return render(request, 'dashboard/settings_detail.html', context)
 
 
-def container_view(request, container_id):
+def container_view(request: HttpRequest, container_id: int) -> HttpResponse:
     """Render the container chat page."""
     if not request.user.is_authenticated:
         return redirect('login')
@@ -36,7 +38,7 @@ def container_view(request, container_id):
     return render(request, 'dashboard/container.html', context)
 
 
-def containers_list_view(request):
+def containers_list_view(request: HttpRequest) -> HttpResponse:
     """Render a list of available containers."""
     if not request.user.is_authenticated:
         return redirect('login')

--- a/users/backends.py
+++ b/users/backends.py
@@ -1,6 +1,10 @@
+from typing import Any, Optional
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import BaseBackend
+from django.contrib.auth.models import AbstractBaseUser
 from django.db.models import Q
+from django.http import HttpRequest
 
 class EmailOrUsernameBackend(BaseBackend):
     """
@@ -8,7 +12,14 @@ class EmailOrUsernameBackend(BaseBackend):
     Allows login with either username or email.
     """
 
-    def authenticate(self, request, username=None, password=None, **kwargs):
+    def authenticate(
+        self,
+        request: HttpRequest | None,
+        username: str | None = None,
+        password: str | None = None,
+        **kwargs: Any,
+    ) -> Optional[AbstractBaseUser]:
+        """Authenticate a user by matching the username or email and checking the password."""
         UserModel = get_user_model()
         user = UserModel.objects.filter(
             Q(username__iexact=username) | Q(email__iexact=username)
@@ -18,7 +29,8 @@ class EmailOrUsernameBackend(BaseBackend):
             return user
         return None
 
-    def get_user(self, user_id):
+    def get_user(self, user_id: int) -> Optional[AbstractBaseUser]:
+        """Retrieve a user instance by its primary key."""
         UserModel = get_user_model()
         try:
             return UserModel.objects.get(pk=user_id)


### PR DESCRIPTION
## Summary
- add type hints and docstrings to dashboard views
- document API view methods and container viewset actions
- annotate custom authentication backend

## Testing
- `mypy --ignore-missing-imports dashboard/views.py dashboard/api_views.py users/backends.py`
- `GOOGLE_API_KEY=dummy SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a18fe3c528832788303f0ed00c7637