### PR TITLE
Refactor: use pathlib for path operations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,13 +5,14 @@
 
 import os
 import sys
+from pathlib import Path
 import django
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 # Point to your Django project's root directory
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 # Set up Django
 os.environ['DJANGO_SETTINGS_MODULE'] = 'portal.settings'
 django.setup()

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -1,7 +1,6 @@
 
 
 
-import os
 import json
 import logging
 from pathlib import Path
@@ -16,7 +15,7 @@ env = environ.Env()
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Take environment variables from .env file
-environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
+environ.Env.read_env(BASE_DIR / '.env')
 
 
 class JsonFormatter(logging.Formatter):


### PR DESCRIPTION
## Summary
- replace remaining os.path references with pathlib.Path in settings and docs configuration

## Testing
- `SECRET_KEY=test GOOGLE_API_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a19afa3de88327aa1cf87900919e8a