### PR TITLE
Document environment variables and reference example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,37 @@
-
-
 # Django Settings
+# Enable debug mode (set to False in production)
 DEBUG=True
 # Generate a new secret key for production. You can use:
 # python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
-# SECRET_KEY is required
 SECRET_KEY=
+# Comma-separated list of hostnames allowed to connect
 ALLOWED_HOSTS=127.0.0.1,localhost
 
+# Origins allowed for CSRF protection
 CSRF_TRUSTED_ORIGINS=http://localhost,http://127.0.0.1
+# Use secure cookies over HTTPS in production
 SESSION_COOKIE_SECURE=False
 CSRF_COOKIE_SECURE=False
+# Controls cross-site cookie sending
 SESSION_COOKIE_SAMESITE=Lax
 
-# Database URL
-# The default is set to connect to the PostgreSQL container from docker-compose.
+# Database connection string
+# Default uses the PostgreSQL container defined in docker-compose
 DATABASE_URL=postgres://user:password@db:5432/ai_portal
-
-# --- ALTERNATIVE (for non-docker, local dev) ---
+# Alternative for local development without Docker
 # DATABASE_URL=sqlite:///db.sqlite3
 
-# Use localhost Redis when running without Docker
+# Redis connection string used by Channels and Celery
+REDIS_URL=redis://redis:6379/1
+# Alternative when running without Docker
 # REDIS_URL=redis://localhost:6379/0
 
-
-# Redis URL for Caching and Channels
-REDIS_URL=redis://redis:6379/1
-
-# AI Provider API Keys (GOOGLE_API_KEY is required)
+# AI Provider API Keys
+# Required API key for Gemini (Google Generative AI)
 GOOGLE_API_KEY=
+# Optional alias used by front-end build scripts
+GEMINI_API_KEY=
+# Optional keys for additional providers
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GROQ_API_KEY=
@@ -36,4 +39,5 @@ GROQ_API_KEY=
 # Microsoft Entra ID (Azure AD) Authentication
 MS_CLIENT_ID=
 MS_CLIENT_SECRET=
+# Tenant authority URL, typically includes your tenant ID
 MS_AUTHORITY=https://login.microsoftonline.com/common

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Copy the example environment file. The default settings are now configured for t
 ```bash
 cp .env.example .env
 ```
-You will need to edit this file to add your API keys for AI providers and Microsoft Entra ID.
+You will need to edit this file to add your API keys for AI providers and Microsoft Entra ID. The `.env.example` file includes comments and default values for every setting.
 
 #### Key Environment Variables
 


### PR DESCRIPTION
## Summary
- annotate `.env.example` with comments and default values for all settings, including new `GEMINI_API_KEY` alias
- mention `.env.example` in README for inline environment variable guidance

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 GOOGLE_API_KEY=dummy python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a846ec9c8327b5651eba2ba1b617