### PR TITLE
Add Python linting tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for common project tasks
 
-.PHONY: docs start help
+.PHONY: docs start help lint
 
 docs:
 	@echo "Building Sphinx documentation..."
@@ -13,7 +13,12 @@ start:
 	@docker-compose exec web python manage.py makemigrations dashboard
 	@docker-compose exec web python manage.py migrate
 
+lint:
+	black --check .
+	flake8
+
 help:
 	@echo "Available commands:"
 	@echo "  make docs    - Build the Sphinx documentation."
 	@echo "  make start   - Build containers and run migrations."
+	@echo "  make lint    - Run code style checks."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 88
+target-version = ["py312"]
+exclude = ["node_modules", "static"]
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503"]
+exclude = ["node_modules", "static"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,7 @@ msal==1.28.0
 Pillow==11.3.0
 requests==2.32.3
 bleach==6.2.0
+
+# Code Quality
+black==25.1.0
+flake8==7.3.0


### PR DESCRIPTION
## Summary
- add black and flake8 dependencies
- configure linting in pyproject.toml
- provide `make lint` command to run black and flake8

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 GOOGLE_API_KEY=dummy python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a1aeb2b830832783c98cbbec91564c