### PR TITLE
Add markdownToHtml unit tests

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { markdownToHtml } from "../utils";
+
+describe("markdownToHtml", () => {
+  it("converts headings", () => {
+    const html = markdownToHtml("# Title");
+    expect(html).toContain("<h1>Title</h1>");
+  });
+
+  it("converts lists", () => {
+    const html = markdownToHtml("- item1\n- item2");
+    expect(html).toContain("<ul>");
+    expect(html).toContain("<li>item1</li>");
+    expect(html).toContain("<li>item2</li>");
+  });
+
+  it("sanitizes malicious input", () => {
+    const html = markdownToHtml('<img src="x" onerror="alert(1)">');
+    expect(html).toContain('src="x"');
+    expect(html).not.toContain("onerror");
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest unit tests for markdownToHtml covering headings, lists and malicious input

## Testing
- `npm test`
- `GOOGLE_API_KEY=dummy SECRET_KEY=test DATABASE_URL=sqlite:///db.sqlite3 REDIS_URL=redis://localhost:6379/0 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b0afc17c8327869b544b2ab2f29b